### PR TITLE
Remove Preflight Step from Workflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ flake8 = "^3.9.1"
 pytest-mock = "^3.5.1"
 coverage = "^5.5"
 responses = "^0.14.0"
+pytest-asyncio = "^0.16.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/servicex_did_finder_lib/communication.py
+++ b/src/servicex_did_finder_lib/communication.py
@@ -35,7 +35,7 @@ async def run_file_fetch_loop(did: str, servicex: ServiceXAdapter, info: Dict[st
         # Track the file, inject back into the system
         summary.add_file(file_info)
         if summary.file_count == 1:
-            servicex.post_preflight_check(file_info)
+            servicex.post_transform_start()
         servicex.put_file_add(file_info)
 
     # Simple error checking and reporting

--- a/src/servicex_did_finder_lib/servicex_adaptor.py
+++ b/src/servicex_did_finder_lib/servicex_adaptor.py
@@ -88,22 +88,20 @@ class ServiceXAdapter:
             self.logger.error(f'After {attempts} tries, failed to send ServiceX App a put_file '
                               f'message: {str(file_info)} - Ignoring error.')
 
-    def post_preflight_check(self, file_entry):
+    def post_transform_start(self):
         success = False
         attempts = 0
         while not success and attempts < MAX_RETRIES:
             try:
-                requests.post(self.endpoint + "/preflight", json={
-                    'file_path': file_entry['file_path']
-                })
+                requests.post(self.endpoint + "/start")
                 success = True
             except requests.exceptions.ConnectionError:
                 self.logger.exception(f'Connection error to ServiceX App. Will retry '
                                       f'(try {attempts} out of {MAX_RETRIES}')
                 attempts += 1
         if not success:
-            self.logger.error(f'After {attempts} tries, failed to send ServiceX App a put_file '
-                              f'message: {str(file_entry)} - Ignoring error.')
+            self.logger.error(f'After {attempts} tries, failed to send ServiceX App a  '
+                              f'transform start message - Ignoring error.')
 
     def put_fileset_complete(self, summary):
         success = False

--- a/tests/servicex_did_finder_lib/test_communication.py
+++ b/tests/servicex_did_finder_lib/test_communication.py
@@ -242,8 +242,7 @@ async def test_run_file_fetch_loop(SXAdaptor, mocker):
             yield v
 
     await run_file_fetch_loop("123-456", SXAdaptor, {}, my_user_callback)
-    SXAdaptor.post_preflight_check.assert_called_once
-    assert SXAdaptor.post_preflight_check.call_args[0][0]['file_path'] == '/tmp/foo'
+    SXAdaptor.post_transform_start.assert_called_once()
 
     assert SXAdaptor.put_file_add.call_count == 2
     assert SXAdaptor.put_file_add.call_args_list[0][0][0]['file_path'] == '/tmp/foo'

--- a/tests/servicex_did_finder_lib/test_servicex_did.py
+++ b/tests/servicex_did_finder_lib/test_servicex_did.py
@@ -45,3 +45,14 @@ def test_put_file_add_with_prefix():
     assert submitted['adler32'] == '32'
     assert submitted['file_events'] == 3141
     assert submitted['file_size'] == 1024
+
+
+@responses.activate
+def test_post_transform_start():
+    responses.add(responses.POST,
+                  'http://servicex.org/servicex/internal/transformation/123-456/start',
+                  status=206)
+
+    sx = ServiceXAdapter("http://servicex.org/servicex/internal/transformation/123-456")
+    sx.post_transform_start()
+    assert len(responses.calls) == 1


### PR DESCRIPTION
# Problem
In order to support multiple code generators we need to remove the preflight step since it is closely tied to specific code generators. Incidentally, this step is not really doing anything useful, so now is a good time to drop it.

Partial solution to [ServiceX Issue 337](https://github.com/ssl-hep/ServiceX/issues/337)

# Approach
Turns out the `run_file_fetch_loop` function was not covered in tests. Added unit tests for this to start with.

To remove the preflight step, we need for the DID finder to explicitly start up the transforms. Instead of posting the `preflight` message (and relying on the preflight service to start the transform) the DID finder can start the transform directly by POSTing the `start` message.