### PR TITLE
Report Fileset Complete Even If Dataset is Empty

### DIFF
--- a/src/servicex_did_finder_lib/communication.py
+++ b/src/servicex_did_finder_lib/communication.py
@@ -42,19 +42,19 @@ async def run_file_fetch_loop(did: str, servicex: ServiceXAdapter, info: Dict[st
     if summary.file_count == 0:
         servicex.post_status_update(f'DID Finder found zero files for dataset {did}',
                                     severity='fatal')
-    else:
-        elapsed_time = int((datetime.now()-start_time).total_seconds())
-        servicex.put_fileset_complete(
-            {
-                "files": summary.file_count,
-                "files-skipped": summary.files_skipped,
-                "total-events": summary.total_events,
-                "total-bytes": summary.total_bytes,
-                "elapsed-time": elapsed_time,
-            }
-        )
 
-        servicex.post_status_update(f'Completed load of file in {elapsed_time} seconds')
+    elapsed_time = int((datetime.now()-start_time).total_seconds())
+    servicex.put_fileset_complete(
+        {
+            "files": summary.file_count,
+            "files-skipped": summary.files_skipped,
+            "total-events": summary.total_events,
+            "total-bytes": summary.total_bytes,
+            "elapsed-time": elapsed_time,
+        }
+    )
+
+    servicex.post_status_update(f'Completed load of file in {elapsed_time} seconds')
 
 
 def rabbit_mq_callback(user_callback: UserDIDHandler, channel, method, properties, body,

--- a/tests/servicex_did_finder_lib/test_communication.py
+++ b/tests/servicex_did_finder_lib/test_communication.py
@@ -265,7 +265,6 @@ async def test_run_file_fetch_loop_bad_did(SXAdaptor, mocker):
             yield v
 
     await run_file_fetch_loop("123-456", SXAdaptor, {}, my_user_callback)
-    SXAdaptor.post_preflight_check.assert_not_called
 
     assert SXAdaptor.put_file_add.assert_not_called
     SXAdaptor.put_fileset_complete.assert_not_called

--- a/tests/servicex_did_finder_lib/test_communication.py
+++ b/tests/servicex_did_finder_lib/test_communication.py
@@ -158,7 +158,8 @@ def test_no_files_returned(rabbitmq, SXAdaptor):
 
     # Make sure the file was sent along, along with the completion
     SXAdaptor.put_file_add.assert_not_called()
-    SXAdaptor.put_fileset_complete.assert_not_called()
+    SXAdaptor.put_fileset_complete.assert_called_once()
+    assert SXAdaptor.put_fileset_complete.call_args[0][0]['files'] == 0
     SXAdaptor.post_status_update.assert_any_call(ANY, severity='fatal')
 
 
@@ -267,9 +268,9 @@ async def test_run_file_fetch_loop_bad_did(SXAdaptor, mocker):
     await run_file_fetch_loop("123-456", SXAdaptor, {}, my_user_callback)
 
     assert SXAdaptor.put_file_add.assert_not_called
-    SXAdaptor.put_fileset_complete.assert_not_called
+    SXAdaptor.put_fileset_complete.assert_called_once()
 
-    assert SXAdaptor.post_status_update.call_args[0][0] == \
+    assert SXAdaptor.post_status_update.call_args_list[0][0][0] == \
         'DID Finder found zero files for dataset 123-456'
 
-    assert SXAdaptor.post_status_update.call_args[1]['severity'] == 'fatal'
+    assert SXAdaptor.post_status_update.call_args_list[0][1]['severity'] == 'fatal'


### PR DESCRIPTION
# Problem
If a Dataset is empty, a status message is posted back to the app but the dataset is never marked as complete, so the transform just hangs there forever.

Fixes #18 

# Approach
Moved the fileset_complete handling out of the `else` block and updated tests.

There was also a straggling assertion on the preflight check that was no longer needed