### PR TITLE
big-db-change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,20 +12,20 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4.0.0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install poetry
-        uses: Gr1N/setup-poetry@v7
+        uses: Gr1N/setup-poetry@v8
       - name: Install dependencies
         run: |
-          poetry install
+          poetry install --with dev
           pip list
       - name: Lint with Flake8
         run: |
@@ -36,7 +36,7 @@ jobs:
           poetry run coverage xml
       - name: Report coverage using codecov
         if: github.event_name == 'push' && matrix.python-version == 3.8
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3.1.4
         with:
           file: ./coverage.xml # optional
           flags: unittests # optional

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.0.0
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.7.0
         with:
           python-version: 3.8
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
       - name: Install poetry
-        uses: Gr1N/setup-poetry@v7
+        uses: Gr1N/setup-poetry@v8
       - name: Build
         run: |
           poetry version ${{ steps.get_version.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ Create an async callback method that `yield`s file info dictionaries. For exampl
 The arguments to the method are straight forward:
 
 * `did_name`: the name of the DID that you should look up. It has the schema stripped off (e.g. if the user sent ServiceX `rucio://dataset_name_in_rucio`, then `did_name` will be `dataset_name_in_rucio`)
-* `info` contains a dict of various info about the request that asked for this DID:
-  * `request-id` The request id that has this DID associated. For logging.
+* `info` contains a dict of various info about the request that asked for this DID.
 
 Yield the results as you find them - ServiceX will actually start processing the files before your DID lookup is finished if you do this. The fields you need to pass back to the library are as follows:
 
@@ -114,7 +113,7 @@ In the end, all DID finders for ServiceX will run under Kubernetes. ServiceX com
     __log = logger.getLogger(__name__)
     async def my_callback(did_name: str, info: Dict[str, Any]):
         __log.info(f'Looking up dataset {did_name}.',
-                     extra={'requestId': info['request-id']})
+                     extra={'somethign': info['something']})
 
         for i in range(0, 10):
             yield {
@@ -125,9 +124,7 @@ In the end, all DID finders for ServiceX will run under Kubernetes. ServiceX com
             }
 ```
 
-Note the parameter `request-id`: this marks the log messages with the request id that triggered this DID request. This will enable the system to track all log messages across all containers connected with this particular request id - making debugging a lot easier.
-
-The `start_did_finder` will configure the python root logger properly to dump messages with a request ID in them.
+The `start_did_finder` will configure the python root logger properly.
 
 ## URI Format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,16 @@ description = "ServiceX DID Library Routines"
 authors = ["Gordon Watts <gwatts@uw.edu>"]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.8"
 pika = "1.1.0"
 make-it-sync = "^1.0.0"
 requests = "^2.25.0"
 
-[tool.poetry.dev-dependencies]
-pytest = "^5.2"
+[tool.poetry.group.dev]
+optional = true
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4"
 flake8 = "^3.9.1"
 pytest-mock = "^3.5.1"
 coverage = "^5.5"

--- a/src/servicex_did_finder_lib/did_logging.py
+++ b/src/servicex_did_finder_lib/did_logging.py
@@ -4,10 +4,10 @@ import os
 
 class DIDFormatter(logging.Formatter):
     """
-    Need a customer formatter to allow for logging with request ids that vary.
-    Normally log messages are "level instance component request_id msg" and
-    request_id gets set by initialize_logging but we need a handler that'll let
-    us pass in the request id and have that embedded in the log message
+    Need a customer formatter to allow for logging with dataset ids that vary.
+    Normally log messages are "level instance component dataset_id msg" and
+    dataset_id gets set by initialize_logging but we need a handler that'll let
+    us pass in the dataset id and have that embedded in the log message
     """
 
     def format(self, record: logging.LogRecord) -> str:
@@ -18,10 +18,10 @@ class DIDFormatter(logging.Formatter):
         :return: formatted log message
         """
 
-        if hasattr(record, "requestId"):
+        if hasattr(record, "datasetId"):
             return super().format(record)
         else:
-            setattr(record, "requestId", None)
+            setattr(record, "datasetId", None)
             return super().format(record)
 
 
@@ -36,7 +36,7 @@ def initialize_root_logger(did_scheme: str):
     instance = os.environ.get('INSTANCE_NAME', 'Unknown')
     formatter = DIDFormatter('%(levelname)s ' +
                              f"{instance} {did_scheme}_did_finder " +
-                             '%(requestId)s %(message)s')
+                             '%(datasetId)s %(message)s')
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
     handler.setLevel(logging.INFO)

--- a/tests/servicex_did_finder_lib/test_communication.py
+++ b/tests/servicex_did_finder_lib/test_communication.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 from typing import Any, AsyncGenerator, Dict, Optional
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pika
 import pytest
@@ -28,8 +28,8 @@ class RabbitAdaptor:
         body = json.dumps(
             {
                 "did": did_name,
-                "request_id": "000-111-222-444",
-                "service-endpoint": "http://localhost:2334",
+                "dataset_id": "000-111-222-444",
+                "endpoint": "http://localhost:2334/",
             }
         )
 
@@ -314,7 +314,6 @@ def test_failed_file(rabbitmq, SXAdaptor):
     # Make sure the file was sent along, along with the completion
     SXAdaptor.put_file_add.assert_not_called()
     SXAdaptor.put_fileset_complete.assert_not_called()
-    SXAdaptor.post_status_update.assert_any_call(ANY, severity="fatal")
 
 
 def test_failed_file_after_good(rabbitmq, SXAdaptor):
@@ -343,7 +342,6 @@ def test_failed_file_after_good(rabbitmq, SXAdaptor):
     # Make sure the file was sent along, along with the completion
     SXAdaptor.put_file_add.assert_called_once()
     SXAdaptor.put_fileset_complete.assert_not_called()
-    SXAdaptor.post_status_update.assert_any_call(ANY, severity="fatal")
 
 
 def test_failed_file_after_good_with_avail(rabbitmq, SXAdaptor):
@@ -372,7 +370,6 @@ def test_failed_file_after_good_with_avail(rabbitmq, SXAdaptor):
     # Make sure the file was sent along, along with the completion
     SXAdaptor.put_file_add.assert_called_once()
     SXAdaptor.put_fileset_complete.assert_called_once()
-    SXAdaptor.post_status_update.assert_any_call("Completed load of files in 0 seconds")
 
 
 def test_failed_file_after_good_with_avail_limited_number(rabbitmq, SXAdaptor):
@@ -407,7 +404,6 @@ def test_failed_file_after_good_with_avail_limited_number(rabbitmq, SXAdaptor):
     # Make sure the file was sent along, along with the completion
     SXAdaptor.put_file_add_bulk.assert_called_once()
     SXAdaptor.put_fileset_complete.assert_called_once()
-    SXAdaptor.post_status_update.assert_any_call("Completed load of files in 0 seconds")
 
 
 def test_no_files_returned(rabbitmq, SXAdaptor):
@@ -432,7 +428,6 @@ def test_no_files_returned(rabbitmq, SXAdaptor):
     SXAdaptor.put_file_add.assert_not_called()
     SXAdaptor.put_fileset_complete.assert_called_once()
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["files"] == 0
-    SXAdaptor.post_status_update.assert_any_call(ANY, severity="fatal")
 
 
 def test_rabbitmq_connection_failure(rabbitmq_fail_once, SXAdaptor):
@@ -520,7 +515,6 @@ async def test_run_file_fetch_loop(SXAdaptor, mocker):
             yield v
 
     await run_file_fetch_loop("123-456", SXAdaptor, {}, my_user_callback)
-    SXAdaptor.post_transform_start.assert_called_once()
 
     assert SXAdaptor.put_file_add.call_count == 2
     assert SXAdaptor.put_file_add.call_args_list[0][0][0]["paths"][0] == "/tmp/foo"
@@ -531,8 +525,6 @@ async def test_run_file_fetch_loop(SXAdaptor, mocker):
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["files-skipped"] == 0
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["total-events"] == 192
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["total-bytes"] == 3070
-
-    assert SXAdaptor.post_status_update.called_once()
 
 
 @pytest.mark.asyncio
@@ -555,7 +547,6 @@ async def test_run_file_bulk_fetch_loop(SXAdaptor, mocker):
         yield return_values
 
     await run_file_fetch_loop("123-456", SXAdaptor, {}, my_user_callback)
-    SXAdaptor.post_transform_start.assert_called_once()
 
     assert SXAdaptor.put_file_add_bulk.call_count == 1
     assert (
@@ -570,8 +561,6 @@ async def test_run_file_bulk_fetch_loop(SXAdaptor, mocker):
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["files-skipped"] == 0
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["total-events"] == 192
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["total-bytes"] == 3070
-
-    assert SXAdaptor.post_status_update.called_once()
 
 
 @pytest.mark.asyncio
@@ -595,7 +584,6 @@ async def test_run_file_fetch_one(SXAdaptor, mocker):
             yield v
 
     await run_file_fetch_loop("123-456?files=1", SXAdaptor, {}, my_user_callback)
-    SXAdaptor.post_transform_start.assert_called_once()
 
     assert SXAdaptor.put_file_add_bulk.call_count == 1
     SXAdaptor.put_file_add_bulk.assert_called_with(
@@ -611,7 +599,6 @@ async def test_run_file_fetch_one(SXAdaptor, mocker):
 
     SXAdaptor.put_fileset_complete.assert_called_once
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["files"] == 1
-    assert SXAdaptor.post_status_update.called_once()
 
 
 @pytest.mark.asyncio
@@ -637,7 +624,6 @@ async def test_run_file_fetch_one_reverse(SXAdaptor, mocker):
             yield v
 
     await run_file_fetch_loop("123-456?files=1", SXAdaptor, {}, my_user_callback)
-    SXAdaptor.post_transform_start.assert_called_once()
 
     assert SXAdaptor.put_file_add_bulk.call_count == 1
     SXAdaptor.put_file_add_bulk.assert_called_with(
@@ -653,7 +639,6 @@ async def test_run_file_fetch_one_reverse(SXAdaptor, mocker):
 
     SXAdaptor.put_fileset_complete.assert_called_once
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["files"] == 1
-    assert SXAdaptor.post_status_update.called_once()
 
 
 @pytest.mark.asyncio
@@ -677,7 +662,6 @@ async def test_run_file_fetch_one_multi(SXAdaptor, mocker):
             yield v
 
     await run_file_fetch_loop("123-456?files=1", SXAdaptor, {}, my_user_callback)
-    SXAdaptor.post_transform_start.assert_called_once()
 
     assert SXAdaptor.put_file_add_bulk.call_count == 1
     SXAdaptor.put_file_add_bulk.assert_called_with(
@@ -693,7 +677,6 @@ async def test_run_file_fetch_one_multi(SXAdaptor, mocker):
 
     SXAdaptor.put_fileset_complete.assert_called_once
     assert SXAdaptor.put_fileset_complete.call_args[0][0]["files"] == 1
-    assert SXAdaptor.post_status_update.called_once()
 
 
 @pytest.mark.asyncio
@@ -707,10 +690,3 @@ async def test_run_file_fetch_loop_bad_did(SXAdaptor, mocker):
 
     assert SXAdaptor.put_file_add.assert_not_called
     SXAdaptor.put_fileset_complete.assert_called_once()
-
-    assert (
-        SXAdaptor.post_status_update.call_args_list[0][0][0]
-        == "DID Finder found zero files for dataset 123-456"
-    )
-
-    assert SXAdaptor.post_status_update.call_args_list[0][1]["severity"] == "fatal"

--- a/tests/servicex_did_finder_lib/test_servicex_did.py
+++ b/tests/servicex_did_finder_lib/test_servicex_did.py
@@ -11,8 +11,8 @@ def test_version():
 
 @responses.activate
 def test_put_file_add():
-    responses.add(responses.PUT, 'http://servicex.org/files', status=206)
-    sx = ServiceXAdapter("http://servicex.org")
+    responses.add(responses.PUT, 'http://servicex.org/12345/files', status=206)
+    sx = ServiceXAdapter("http://servicex.org/", '12345')
     sx.put_file_add({
         'paths': ['root://foo.bar.ROOT'],
         'adler32': '32',
@@ -30,8 +30,8 @@ def test_put_file_add():
 
 @responses.activate
 def test_put_file_add_bulk():
-    responses.add(responses.PUT, 'http://servicex.org/files', status=206)
-    sx = ServiceXAdapter("http://servicex.org")
+    responses.add(responses.PUT, 'http://servicex.org/12345/files', status=206)
+    sx = ServiceXAdapter("http://servicex.org/", '12345')
     sx.put_file_add_bulk([{
         'paths': ['root://foo.bar.ROOT'],
         'adler32': '32',
@@ -59,8 +59,8 @@ def test_put_file_add_bulk():
 
 @responses.activate
 def test_put_file_add_bulk_large():
-    responses.add(responses.PUT, 'http://servicex.org/files', status=206)
-    sx = ServiceXAdapter("http://servicex.org")
+    responses.add(responses.PUT, 'http://servicex.org/12345/files', status=206)
+    sx = ServiceXAdapter("http://servicex.org/", '12345')
     sx.put_file_add_bulk([{
         'paths': ['root://foo.bar.ROOT'],
         'adler32': '32',
@@ -68,33 +68,3 @@ def test_put_file_add_bulk_large():
         'file_events': 3141
     }] * 32)
     assert len(responses.calls) == 2
-
-
-@responses.activate
-def test_put_file_add_with_prefix():
-    responses.add(responses.PUT, 'http://servicex.org/files', status=206)
-    sx = ServiceXAdapter("http://servicex.org", "xcache123:")
-    sx.put_file_add({
-        'paths': ['root://foo.bar.ROOT'],
-        'adler32': '32',
-        'file_size': 1024,
-        'file_events': 3141
-    })
-
-    assert len(responses.calls) == 1
-    submitted = json.loads(responses.calls[0].request.body)
-    assert submitted['paths'][0] == 'xcache123:root://foo.bar.ROOT'
-    assert submitted['adler32'] == '32'
-    assert submitted['file_events'] == 3141
-    assert submitted['file_size'] == 1024
-
-
-@responses.activate
-def test_post_transform_start():
-    responses.add(responses.POST,
-                  'http://servicex.org/servicex/internal/transformation/123-456/start',
-                  status=206)
-
-    sx = ServiceXAdapter("http://servicex.org/servicex/internal/transformation/123-456")
-    sx.post_transform_start()
-    assert len(responses.calls) == 1


### PR DESCRIPTION
A lot of changes going for version 2.0.0
* now it knows nothing about request_id but knows about dataset.
* it calls new servicex endpoints (not having request_id but dataset_id as a parameter).
* removed all calls to request start endpoint as that one does not exist anymore
* removed all calls to request status as it knows nothing about requests 
* removed everything related to xcache prefixes as that is now done in transformers.
* updated all github actions
* put dev dependencies in their own group
* removed py 3.7 as poetry v8 does not support it.
* updates all tests affected by the change