### PR TITLE
Push intermediate results

### DIFF
--- a/src/servicex_did_finder_lib/did_finder_app.py
+++ b/src/servicex_did_finder_lib/did_finder_app.py
@@ -97,8 +97,11 @@ class DIDFinderTask(Task):
         try:
             for file_info in user_did_finder(did_info.did, info, self.app.did_finder_args):
                 acc.add(file_info)
+                if did_info.file_count == -1:
+                    acc.send_on(-1)  # if looking up full dataset, can send partial results
 
-            acc.send_on(did_info.file_count)
+            if did_info.file_count > 0:  # otherwise wait until all files arrive, then limit results
+                acc.send_on(did_info.file_count)
         except Exception:
             # noinspection PyTypeChecker
             self.logger.error(

--- a/src/servicex_did_finder_lib/did_finder_app.py
+++ b/src/servicex_did_finder_lib/did_finder_app.py
@@ -100,7 +100,7 @@ class DIDFinderTask(Task):
                 if did_info.file_count == -1:
                     acc.send_on(-1)  # if looking up full dataset, can send partial results
 
-            if did_info.file_count > 0:  # otherwise wait until all files arrive, then limit results
+            if did_info.file_count > 0:  # otherwise wait until all files arrive then limit results
                 acc.send_on(did_info.file_count)
         except Exception:
             # noinspection PyTypeChecker


### PR DESCRIPTION
Enable partial sending of results from the lookup if we aren't limiting the number of files (in the latter case we want to sort the full list of possible files).